### PR TITLE
Replace Steven & Francisco with Andy.

### DIFF
--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -2,8 +2,7 @@ Keith Smiley @keith (Lyft) - Chair - Until 2/2023
 Scott Berrevoets @sberrevoets (Lyft, secondary) - Until 2/2023
 Patrick Balestra @BalestraPatrick (Spotify) - Until 2/2023
 Dan Fleming @dflems (Spotify, Secondary) - Until 2/2023
-Steven Hepting @shepting (Airbnb) - Until 2/2023
-Francisco Díaz @fdiaz (Airbnb, Secondary) - Until 2/2023
+Andy Bartholomew @jqsilver (Airbnb) - Until 2/2023
 Justin Newitter @justinnewitter (LinkedIn) - Until 2/2023
 Oscar Bonilla @ob (LinkedIn, Secondary) - Until 2/2023
 Ty Smith @tyvsmith (Uber) - Until 2/2023


### PR DESCRIPTION
Proposing that we replace Steven & Francisco with Andy Bartholomew.

Signed-off-by: Steven Hepting <shepting@gmail.com>